### PR TITLE
fix: 🐛`NODE_EVN` should be `NODE_ENV`

### DIFF
--- a/addon/jsx.js
+++ b/addon/jsx.js
@@ -49,7 +49,7 @@ exports.addon = function (renderer) {
                 : fn(copy);
         };
 
-        if (process.env.NODE_EVN !== 'production') {
+        if (process.env.NODE_ENV !== 'production') {
             if (block) {
                 Component.displayName = 'jsx(' + block + ')';
             }

--- a/addon/style.js
+++ b/addon/style.js
@@ -22,7 +22,7 @@ exports.addon = function (renderer) {
             return jsxComponent(copy);
         };
 
-        if (process.env.NODE_EVN !== 'production') {
+        if (process.env.NODE_ENV !== 'production') {
             if (block || (typeof fn === 'function')) {
                 Component.displayName = 'style(' + (block || fn.displayName || fn.name) + ')';
             }


### PR DESCRIPTION
I ran into a problem and found the issue to be a typo - `process.env.NODE_ENV` is misspelled in two places. 